### PR TITLE
Migrate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp-csa/terraform-provider-csa
+module github.com/hashicorp-sa/terraform-provider-csa
 
 go 1.17
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,8 +3,8 @@ package provider
 import (
 	"context"
 
-	"github.com/hashicorp-csa/terraform-provider-csa/client/animals"
-	"github.com/hashicorp-csa/terraform-provider-csa/internal/services/animals"
+	"github.com/hashicorp-sa/terraform-provider-csa/client/animals"
+	animal "github.com/hashicorp-sa/terraform-provider-csa/internal/services/animals"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/services/animals/data_source_animal.go
+++ b/internal/services/animals/data_source_animal.go
@@ -3,7 +3,7 @@ package animal
 import (
 	"context"
 
-	"github.com/hashicorp-csa/terraform-provider-csa/client/animals"
+	"github.com/hashicorp-sa/terraform-provider-csa/client/animals"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/services/animals/data_source_animal_test.go
+++ b/internal/services/animals/data_source_animal_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp-csa/terraform-provider-csa/internal/testing"
+	acceptanceTesting "github.com/hashicorp-sa/terraform-provider-csa/internal/testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 

--- a/internal/services/animals/resource_animal.go
+++ b/internal/services/animals/resource_animal.go
@@ -3,7 +3,7 @@ package animal
 import (
 	"context"
 
-	"github.com/hashicorp-csa/terraform-provider-csa/client/animals"
+	"github.com/hashicorp-sa/terraform-provider-csa/client/animals"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/services/animals/resource_animal_test.go
+++ b/internal/services/animals/resource_animal_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp-csa/terraform-provider-csa/internal/testing"
+	acceptanceTesting "github.com/hashicorp-sa/terraform-provider-csa/internal/testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/internal/testing/testing.go
+++ b/internal/testing/testing.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp-csa/terraform-provider-csa/internal/provider"
+	"github.com/hashicorp-sa/terraform-provider-csa/internal/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 
-	"github.com/hashicorp-csa/terraform-provider-csa/internal/provider"
+	"github.com/hashicorp-sa/terraform-provider-csa/internal/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
@@ -35,7 +35,7 @@ func main() {
 	opts := &plugin.ServeOpts{
 		Debug: debugMode,
 
-		ProviderAddr: "registry.terraform.io/hashicorp-csa/demo-private-provider-csa-provider",
+		ProviderAddr: "registry.terraform.io/hashicorp-sa/demo-private-provider-csa-provider",
 
 		ProviderFunc: provider.New(version),
 	}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,39 @@
+provider "github" {
+  # token = var.token # or `GITHUB_TOKEN`
+}
+
+data "github_actions_public_key" "my_public_key" {
+  repository = "demo-private-provider-csa-provider"
+}
+
+
+# https://developer.hashicorp.com/terraform/tutorials/providers/provider-release-publish?in=terraform%2Fproviders#add-github-secrets-for-github-action
+resource "github_actions_secret" "gpg_private_key" {
+  repository       = data.github_actions_public_key.my_public_key.repository
+  secret_name      = "GPG_PRIVATE_KEY"
+  plaintext_value  =file(var.gpg_private_key)
+}
+
+resource "github_actions_secret" "passphrase" {
+  repository       = data.github_actions_public_key.my_public_key.repository
+  secret_name      = "PASSPHRASE"
+  plaintext_value  = var.passphrase
+}
+
+resource "github_actions_secret" "tf_url" {
+  repository       = data.github_actions_public_key.my_public_key.repository
+  secret_name      = "TF_URL"
+  plaintext_value  = var.tf_url
+}
+
+resource "github_actions_secret" "tf_token" {
+  repository       = data.github_actions_public_key.my_public_key.repository
+  secret_name      = "TF_TOKEN"
+  plaintext_value  = var.tf_token
+}
+
+resource "github_actions_secret" "tf_org" {
+  repository       = data.github_actions_public_key.my_public_key.repository
+  secret_name      = "TF_ORG"
+  plaintext_value  = var.tf_org
+}


### PR DESCRIPTION
ChangeLog:

1. Find Replace of HashiCorp-CSA to HashiCorp-CS
2. Need to validate that the README.md changes & TF code generate prerequisites for GPG & GH vs. doing it manually

What comes next:

1. Rename the Repository From CSA to CS
2. Rename the TFC Workspace to Reflect the Change

